### PR TITLE
Add namespace level in serial peripheral template

### DIFF
--- a/dral/templates/cpp/serial/peripheral.dral
+++ b/dral/templates/cpp/serial/peripheral.dral
@@ -5,7 +5,7 @@
 
 [dral]include model.import.dral[#dral]
 
-namespace dral::[dral style="lowercase"]device.name[#dral] {
+namespace dral::[dral style="lowercase"]device.name[#dral]::[dral style="lowercase"]peripheral.name[#dral] {
 
 [dral template="register.dral"]peripheral.registers[#dral]
 


### PR DESCRIPTION
In case where two peripherals have a register with the same name and serial generator is used, the generated C++ code is ambiguous.

Example:
```yaml
device:
  name: STM32F411
  description: STM32F411
  peripherals:
    - name: TIM1
      description: "General purpose timers"
      address: 0x50000000
      registers:
        - name: CR1
          description: control register 1
          offset: 0x20
          fields: []
    - name: TIM2
      description: "General purpose timers"
      address: 0x40000000
      registers:
        - name: CR1
          description: control register 1
          offset: 0x00
          fields: []
```

Generated are 2 files, tim1.h and tim2.h

tim1.h:

```cpp
#ifndef DRAL_STM32F411_TIM1_H
#define DRAL_STM32F411_TIM1_H

#include "../register_model.h"

namespace dral::stm32f411 {

struct cr1
{
...
```

tim2.h:

```cpp
#ifndef DRAL_STM32F411_TIM2_H
#define DRAL_STM32F411_TIM2_H

#include "../register_model.h"

namespace dral::stm32f411 {

struct cr1
{
...
```

Struct `dral::stm32f411::cr1` is defined twice in this case and compilation fails with `error: redefinition of ‘struct dral::stm32f411::cr1’`.

A possible solution is to add another namespace level to the peripheral template.
