### PR TITLE
Add custom data support to Register model

### DIFF
--- a/dral/types.py
+++ b/dral/types.py
@@ -68,6 +68,7 @@ class Register(DralBaseType):
         description: str = "",
         reset_value: Optional[int] = None,
         fields: Optional[List[Field]] = None,
+        **custom_data,
     ):
         super().__init__(name, description)
         self._offset = offset
@@ -78,6 +79,7 @@ class Register(DralBaseType):
         if fields is None:
             fields = []
         self._fields = fields
+        self._custom_data = custom_data
 
     def asdict(self) -> Dict[str, Any]:
         return {
@@ -87,6 +89,7 @@ class Register(DralBaseType):
             "size": self._size,
             "reset_value": self._reset_value,
             "fields": [field.asdict() for field in self._fields],
+            **self._custom_data,
         }
 
     @property

--- a/dral/types.py
+++ b/dral/types.py
@@ -143,7 +143,7 @@ class Peripheral(DralBaseType):
     def __init__(
         self,
         name: str,
-        address: int,
+        address: int = 0,
         description: str = "",
         registers: Optional[List[Register]] = None,
         banks: Optional[List[Bank]] = None,


### PR DESCRIPTION
This change adds the possibility to pass custom data defined in device description file to the template engine.
It allows D-RAL to generate output files with device specific data, which isn't necessarily needed in a general case.
This can be for example `RegBank` which is specific to an ethernet controller I'm using.

---

Usage example:

YAML device description file:
```yaml
registers:
- name: DMADSTL
  description: DMA Destination Low Byte
  size: 8
  offset: 0x14
  reset_value: 0x00
  reg_bank: 0
  fields: []
```

Peripheral template:
```cpp
struct {{ register.name | lower | isforbidden }}
{
  constexpr static uint8_t Address = {{ "0x{:02X}".format(register.offset) }};
  {%- if register.reg_bank is defined %}
  constexpr static uint8_t RegBank = {{ "0x{:02X}".format(register.reg_bank) }};
  {%- endif %}
```

This also requires a custom adapter which includes these custom fields in D-RAL model.

---

This is still a draft - the changes can be extended to other D-RAL types, rewritten in some other way, tests added etc.